### PR TITLE
manejo de bloqueos

### DIFF
--- a/src/games/games.controller.ts
+++ b/src/games/games.controller.ts
@@ -21,15 +21,15 @@ export class GamesController {
   }
   @Post('/trivia-categoria')
   async createGame(@Body() createGameDto: CreateGameDto) {
-    const game=  this.gamesService.createGame(createGameDto);
+    const game=  await this.gamesService.createGame(createGameDto);
     return {
-      id: (await game).id,
-      category: (await game).category,
-      difficulty: (await game).difficulty,
-      questions: (await game).questions,
+      id: game.id,
+      category: game.category,
+      difficulty: game.difficulty,
+      questions: game.questions,
       player: {
-          id: (await game).player.id,
-          score: (await game).player.score 
+          id: game.player.id,
+          score:  game.player.score 
       }
   };
   }

--- a/src/games/games.module.ts
+++ b/src/games/games.module.ts
@@ -12,6 +12,7 @@ import { QuestionsService } from 'src/questions/questions.service';
 import { answerProviders } from 'src/answer/answer.providers';
 
 
+
 @Module({
   imports:[DatabaseModule],
   controllers: [GamesController],
@@ -23,7 +24,8 @@ import { answerProviders } from 'src/answer/answer.providers';
     ...gameProviders,
     ...answerProviders,
     CategoryService,
-    QuestionsService
+    QuestionsService,
+   
 
   ],
   exports: [...gameProviders],

--- a/src/questions/questions.controller.ts
+++ b/src/questions/questions.controller.ts
@@ -18,6 +18,8 @@ export class QuestionsController {
     return await this.questionsService.getRandomQuestions();
   }
 
+
+
   @Post()
   async createMultipleQuestionWithAnswers(@Body() createQuestionDto: CreateQuestionDto[]) {
     return this.questionsService.createMultipleQuestionsWithAnswers(createQuestionDto);

--- a/src/questions/questions.service.ts
+++ b/src/questions/questions.service.ts
@@ -67,7 +67,9 @@ export class QuestionsService {
       return question;
   }
 
-  async getRandomQuestions() {
+
+
+  async getRandomQuestions() : Promise<Question[]> {
     try{
       const questions = await this.questionRepository.find({
         relations:['answers'] });;
@@ -75,6 +77,12 @@ export class QuestionsService {
           throw new Error('question Not found')};
 
       const randomQuestions = this.categoryService.shuffleArray(questions).slice(0,30)
+      
+
+      if (randomQuestions.length === 0) {
+        throw new Error('Not enough random questions found');
+      }
+  
 
       return randomQuestions;
     } catch (err) {


### PR DESCRIPTION
Se acomodo el codigo para crear partidas por categoria que al necesitar tantos datos de otras entidades al momento de crear una partida, y ser un metodo asincronico cuando tardaba la base producia un bloqueo...y generaba un error de tipo deadLock en la consola.